### PR TITLE
Added attributionSession function

### DIFF
--- a/src/en-session-attribution.ts
+++ b/src/en-session-attribution.ts
@@ -5,7 +5,7 @@ declare global {
   interface Window {
     additionalCommentsTag: string;
     parentSession: string;
-    attributionSession: () => string;
+    attributionSession: string;
   }
 }
 
@@ -433,9 +433,7 @@ function sessionAttribution(updatepage = true, mirroredSession = '') {
       debugSession(currentSession);
     }
 
-    window.attributionSession = function () {
-      return getSessionObj(currentSession);
-    };
+    window.attributionSession = getSessionObj(currentSession);
     window.parentSession = currentSession;
     return;
   });

--- a/src/en-session-attribution.ts
+++ b/src/en-session-attribution.ts
@@ -5,6 +5,7 @@ declare global {
   interface Window {
     additionalCommentsTag: string;
     parentSession: string;
+    attributionSession: () => string;
   }
 }
 
@@ -432,6 +433,9 @@ function sessionAttribution(updatepage = true, mirroredSession = '') {
       debugSession(currentSession);
     }
 
+    window.attributionSession = function () {
+      return getSessionObj(currentSession);
+    };
     window.parentSession = currentSession;
     return;
   });


### PR DESCRIPTION
I've created a function that can be accessed from the browser called `attributionSession()` that will return the session data as an object. This allows you to view the session without having to put `debug=true` in the page URL. Just open the console and run `attributionSession()` to retrieve the data.